### PR TITLE
修复点击 “人机练习” 按钮时触发异常的问题

### DIFF
--- a/app-lite/lib/cchess/cc_base.dart
+++ b/app-lite/lib/cchess/cc_base.dart
@@ -105,7 +105,12 @@ class Move {
     step += String.fromCharCode('a'.codeUnitAt(0) + tx) + (9 - ty).toString();
   }
 
-  Move.fromCoordinate(int fx, int fy, int tx, int ty) {
+  Move.fromCoordinate(int fromX, int fromY, int toX, int toY) {
+    fx = fromX;
+    fy = fromY;
+    tx = toX;
+    ty = toY;
+
     from = fx + fy * 9;
     to = tx + ty * 9;
     captured = Piece.empty;

--- a/app-lite/lib/cchess/move_recorder.dart
+++ b/app-lite/lib/cchess/move_recorder.dart
@@ -1,5 +1,3 @@
-import 'package:sprintf/sprintf.dart';
-
 import 'cc_base.dart';
 
 class MoveRecorder {


### PR DESCRIPTION
异常信息为：

```
LateInitializationError: Field 'fx' has not been initialized.
```

原因为当调用 `Move.fromCoordinate` 函数时，未给 fx 等变量初始化，那么，在运行到

```dart
static String nameOf(Phase phase, Move step)
```

的 

```dart
return '$chessName${colNames[sideIndex][step.fx]}';
```

这行时，因为 `step.fx` 未初始化而抛出异常。

